### PR TITLE
Added decorators subsystem

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -7,6 +7,7 @@ use Pagekit\Application\ServiceProviderInterface;
 use Pagekit\Application\Provider\RoutingServiceProvider;
 use Pagekit\Application\Traits\EventTrait;
 use Pagekit\Application\Traits\StaticTrait;
+use Pagekit\Decorator\DecoratorServiceProvider;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -40,6 +41,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
         };
 
         $this->register(new RoutingServiceProvider);
+        $this->register(new DecoratorServiceProvider($this['loader']));
     }
 
     /**

--- a/src/Decorator/Decorator.php
+++ b/src/Decorator/Decorator.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Pagekit\Decorator;
+
+
+class Decorator {
+	protected $decorated_object;
+	protected $decoration_context;
+
+	function __construct($object, $context = null){
+		$this->decorated_object = $object;
+		$this->decoration_context = $context;
+	}
+
+	function __call($method, $arguments){
+		call_user_func_array([$this->decorated_object, $method], $arguments);
+	}
+
+	function __get($property){
+		return $this->decorated_object->$property;
+	}
+
+	function __set($property, $value){
+		$this->decorated_object->$property = $value;
+	}
+}

--- a/src/Decorator/DecoratorCollection.php
+++ b/src/Decorator/DecoratorCollection.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Pagekit\Decorator;
+
+use Composer\Autoload\ClassLoader;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use PageKit\Decorator\Event\DecorateEvent;
+
+class DecoratorCollection implements EventSubscriberInterface {
+	protected $loader;
+	protected $decorators;
+
+	function __construct(ClassLoader $loader){
+		$this->loader = $loader;
+	}
+
+	public function add($className, $decoratorClassName, $priority = 50){
+		$this->decorators[$className][$priority] []= $decoratorClassName;
+		ksort($this->decorators[$className]);
+	}
+
+	public function decorate($object, $context = null){
+		$className = get_class($object);
+		if (!empty($this->decorators[$className])){
+			$decoratorClassesByPriority = $this->decorators[$className];
+			foreach($decoratorClassesByPriority as $priority => $decoratorClasses){
+				$object = $this->instantiateDecorators($object, $decoratorClasses, $context);
+			}
+		}
+		return $object;
+	}
+
+	protected function instantiateDecorators($object, $decoratorClasses, $context = null){
+		foreach($decoratorClasses as $class){
+			$object = new $class($object, $context);
+		}
+		return $object;
+	}
+
+	public function onDecorateRequested(DecorateEvent $decorateEvent){
+		$decorateEvent->setDecoratedObject($this->decorate($decorateEvent->getObject(), $decorateEvent->getContext()));
+	}
+
+	public static function getSubscribedEvents()
+	{
+		return [
+			'decorators.decorate' => ['onDecorateRequested', 8]
+		];
+	}
+}

--- a/src/Decorator/DecoratorServiceProvider.php
+++ b/src/Decorator/DecoratorServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Pagekit\Decorator;
+
+use Pagekit\Application\ServiceProviderInterface;
+use Pagekit\Application;
+
+class DecoratorServiceProvider implements ServiceProviderInterface {
+	/**
+	 * {@inheritdoc}
+	 */
+	public function register(Application $app)
+	{
+		$app['decorators'] = function($app) {
+			return new DecoratorCollection($app['autoloader']);
+		};
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function boot(Application $app)
+	{
+		$app->subscribe($app['decorators']);
+	}
+}
+

--- a/src/Decorator/Event/DecorateEvent.php
+++ b/src/Decorator/Event/DecorateEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Pagekit\Decorator\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class DecorateEvent extends Event{
+	protected $object;
+	protected $decoratedObject;
+	protected $context;
+
+	function __construct($object, $context = null){
+		$this->object = $object;
+		$this->decoratedObject = $object;
+		$this->context = $context;
+	}
+
+	function getContext(){
+		return $this->context;
+	}
+	function getObject(){
+		return $this->object;
+	}
+
+	function setDecoratedObject($decoratedObject){
+		$this->decoratedObject = $decoratedObject;
+	}
+
+	function getDecoratedObject(){
+		return $this->decoratedObject;
+	}
+}

--- a/src/Routing/Controller/ControllerReader.php
+++ b/src/Routing/Controller/ControllerReader.php
@@ -83,15 +83,16 @@ class ControllerReader implements ControllerReaderInterface
 
             if ($method->isPublic() && 'Action' == substr($method->name, -6)) {
 
-                $count = $this->routes->count();
+                $routeAdded = false;
 
                 foreach ($this->getAnnotationReader()->getMethodAnnotations($method) as $annotation) {
                     if ($annotation instanceof $this->routeAnnotation) {
                         $this->addRoute($class, $method, $globals, $annotation);
+                        $routeAdded = true;
                     }
                 }
 
-                if ($count == $this->routes->count()) {
+                if (!$routeAdded) {
                     $this->addRoute($class, $method, $globals, new $this->routeAnnotation([]));
                 }
             }

--- a/src/Routing/Controller/ControllerResolver.php
+++ b/src/Routing/Controller/ControllerResolver.php
@@ -2,7 +2,9 @@
 
 namespace Pagekit\Routing\Controller;
 
+
 use Pagekit\Routing\Event\GetControllerEvent;
+use Pagekit\Decorator\Event\DecorateEvent;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -30,6 +32,12 @@ class ControllerResolver extends BaseResolver
      */
     public function getController(Request $request)
     {
-        return $this->events->dispatch('controller.resolve', new GetControllerEvent($request))->getController() ?: parent::getController($request);
+        $controller = $this->events->dispatch('controller.resolve', new GetControllerEvent($request))->getController() ?: parent::getController($request);
+        if ($controller && is_array($controller) && is_object($controller[0])){
+            $this->events->dispatch('decorators.decorate', $event = new DecorateEvent($controller[0]));
+            $controller[0] = $event->getDecoratedObject();
+        }
+        return $controller;
+
     }
 }


### PR DESCRIPTION
I thought a lot about the ways existing PageKit behaviour can be customised by extensions. The first problem came to mind was "how do I modify existing controllers to fetch additional data for rendering or do some post-processing after the main controller action was executed". So, I think creating stacked prioritised decorators with pass-through for untouched methods will do the trick and make Pagekit truly flexible and extendable with minimal efforts.